### PR TITLE
[#107] ensia96 (2026-01-10)

### DIFF
--- a/interface.tf.json
+++ b/interface.tf.json
@@ -76,8 +76,8 @@
                   {
                     "backend": {
                       "service": {
-                        "name": "dashboard-kong-proxy",
-                        "port": { "number": 443 }
+                        "name": "dashboard-kubernetes-dashboard-web",
+                        "port": { "number": 8000 }
                       }
                     },
                     "path": "/",


### PR DESCRIPTION
Closes #107

## Summary
- ingress backend를 `dashboard-kong-proxy`에서 `dashboard-kubernetes-dashboard-web`으로 변경
- naming.md 규칙 준수: 부가 컴포넌트(kong-proxy) 대신 핵심 기능(kubernetes-dashboard-web) 사용

## 이전 PR 브랜치명 규칙 위반 정리
- PR #109, #110: 코드 변경은 정상이나 브랜치명이 `fix/...` 형식으로 규칙 위반
- 잘못된 브랜치 삭제 완료:
  - `fix/restore-repository-dispatch`
  - `fix/workflow-dispatch-apply`
  - `107-task-kubernetes-dashboard-로-전환`