### PR TITLE
[#117] ensia96 (2026-06-15)

### DIFF
--- a/compute.tf.json
+++ b/compute.tf.json
@@ -31,7 +31,7 @@
               "subnet_id": "${oci_core_subnet.private.id}"
             }
           ],
-          "size": 2
+          "size": 1
         },
         "node_shape": "VM.Standard.A1.Flex",
         "node_shape_config": { "memory_in_gbs": 12, "ocpus": 2 },


### PR DESCRIPTION
## Summary

OCI 무료 플랜 변경 대응을 위해 OKE main node pool size를 2에서 1로 축소합니다.
비용 발생 방지를 위한 우선 조치입니다.

## Note
- 1-node 구성으로 인해 가용성은 낮아질 수 있습니다.
- 적용 후 Traefik replica 및 리소스 분배는 별도로 재검토합니다.

## Why

OCI 무료 플랜 변경 대응을 위한 main node pool size 축소

## Verification

- [ ] PR Terraform plan에서 `oci_containerengine_node_pool.main`의 size 변경만 발생하는지 확인합니다.
- [ ] 예상치 못한 리소스 재생성 또는 destroy가 없는지 확인합니다.

## Links

Closes #117