### PR TITLE
[#117] ensia96 (2026-06-15)

### DIFF
--- a/interface.tf.json
+++ b/interface.tf.json
@@ -10,10 +10,9 @@
         "wait": false
       },
       "dashboard": {
-        "chart": "kubernetes-dashboard",
+        "chart": "https://github.com/kubernetes-retired/dashboard/releases/download/kubernetes-dashboard-7.14.0/kubernetes-dashboard-7.14.0.tgz",
         "name": "dashboard",
         "namespace": "${kubernetes_namespace_v1.system.metadata.0.name}",
-        "repository": "https://kubernetes.github.io/dashboard/",
         "values": ["${jsonencode(local.dashboard-values)}"]
       },
       "metrics": {


### PR DESCRIPTION
## Summary

PR #119 merge 후 main apply가 Kubernetes Dashboard Helm chart repository 404로 실패하여 후속 수정입니다.

- `helm_release.dashboard`의 사라진 repository `https://kubernetes.github.io/dashboard/` 의존을 제거했습니다.
- chart를 Kubernetes Dashboard 7.14.0 release tgz URL로 직접 고정했습니다.
- values 및 다른 인프라 설정은 변경하지 않았습니다.

Failed workflow: https://github.com/ensia96/platform/actions/runs/27526112696

## Why

목표는 OKE main node pool size 2 -> 1 적용을 막는 현재 apply blocker만 최소 수정으로 제거하는 것입니다. 인프라 재정비는 별도 작업으로 미룹니다.

이 PR은 #117 해결을 위한 부속/해결 작업입니다. 이미 merged된 PR이므로 자동 close 실효성은 제한적일 수 있지만, 이력상 의도를 명확히 하기 위해 `Fixes #117`로 정리합니다.

## Verification

- [ ] PR Terraform plan에서 `helm_release.dashboard` chart repository 404 오류가 해소되는지 확인합니다.
- [ ] Dashboard Helm chart source가 직접 tgz URL로 고정되어 plan/apply가 chart를 찾을 수 있는지 확인합니다.
- [ ] 남은 apply 대상이 node pool size 축소, tailscale key 생성, bastion replacement 범위인지 확인합니다.

## Links

Fixes #117